### PR TITLE
Publish type definitions (fixes #45)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 *
 
-!dist
+!dist/**
 !package.json
 !LICENSE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsqr",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A pure javascript QR code reading library that takes in raw images and will locate, extract and parse any QR code found within.",
   "repository": "https://github.com/cozmo/jsQR",
   "main": "./dist/jsQR.js",


### PR DESCRIPTION
Previously I think this was not doing what was expected, specifically we weren't actually including anything in the `dist` folder. Rather `dist/jsQR.js` was being included only because it was listed as the entry point in `package.json`. This change is now _correctly_ including any files in the `dist` folder. 

Can be verified by running `npm pack` and then seeing the output is expected. 