### PR TITLE
Add option to disable inverting

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ If you want to use jsQR to scan a webcam stream you'll need to extract the [`Ima
 
 ## Usage
 
-jsQR exports a method that takes in 3 arguments representing the image data you wish to decode.
+jsQR exports a method that takes in 3 arguments representing the image data you wish to decode. Additionally can take an options object to further configure scanning behavior.
 
 ```javascript
-const code = jsQR(imageData, width, height);
+const code = jsQR(imageData, width, height, options?);
 
 if (code) {
   console.log("Found QR code", code);
@@ -61,7 +61,9 @@ if (code) {
 As such the length of this array should be `4 * width * height`.
 This data is in the same form as the [`ImageData`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData) interface, and it's also [commonly](https://www.npmjs.com/package/jpeg-js#decoding-jpegs) [returned](https://github.com/lukeapage/pngjs/blob/master/README.md#property-data) by node modules for reading images.
 - `width` - The width of the image you wish to decode.
-- `height` The height of the image you wish to decode.
+- `height` - The height of the image you wish to decode.
+- `options` (optional) - Additional options.
+  - `attemptInverted` - (default: `true`) - Should jsQR attempt to invert the image to find QR codes with white modules on black backgrounds instead of the black modules on white background. This option defaults to true for backwards compatibility but causes a ~50% performance hit, and will probably be disabled in future versions.
 
 ### Return value
 If a QR is able to be decoded the library will return an object with the following keys.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -15,5 +15,8 @@ export interface QRCode {
         bottomRightAlignmentPattern?: Point;
     };
 }
-declare function jsQR(data: Uint8ClampedArray, width: number, height: number): QRCode | null;
+export interface Options {
+    attemptInverted?: boolean;
+}
+declare function jsQR(data: Uint8ClampedArray, width: number, height: number, options?: Options): QRCode | null;
 export default jsQR;

--- a/dist/jsQR.js
+++ b/dist/jsQR.js
@@ -357,10 +357,17 @@ function scan(matrix) {
         },
     };
 }
-function jsQR(data, width, height) {
+var defaultOptions = {
+    attemptInverted: true,
+};
+function jsQR(data, width, height, options) {
+    var actualOpts = defaultOptions;
+    Object.keys(options || {}).forEach(function (opt) {
+        actualOpts[opt] = options[opt];
+    });
     var binarized = binarizer_1.binarize(data, width, height);
     var result = scan(binarized);
-    if (!result) {
+    if (!result && actualOpts.attemptInverted) {
         result = scan(binarized.getInverted());
     }
     return result;

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,9 @@
         canvasElement.width = video.videoWidth;
         canvas.drawImage(video, 0, 0, canvasElement.width, canvasElement.height);
         var imageData = canvas.getImageData(0, 0, canvasElement.width, canvasElement.height);
-        var code = jsQR(imageData.data, imageData.width, imageData.height);
+        var code = jsQR(imageData.data, imageData.width, imageData.height, {
+          attemptInverted: false,
+        });
         if (code) {
           drawLine(code.location.topLeftCorner, code.location.topRightCorner, "#FF3B58");
           drawLine(code.location.topRightCorner, code.location.bottomRightCorner, "#FF3B58");

--- a/docs/jsQR.js
+++ b/docs/jsQR.js
@@ -357,10 +357,17 @@ function scan(matrix) {
         },
     };
 }
-function jsQR(data, width, height) {
+var defaultOptions = {
+    attemptInverted: true,
+};
+function jsQR(data, width, height, options) {
+    var actualOpts = defaultOptions;
+    Object.keys(options || {}).forEach(function (opt) {
+        actualOpts[opt] = options[opt];
+    });
     var binarized = binarizer_1.binarize(data, width, height);
     var result = scan(binarized);
-    if (!result) {
+    if (!result && actualOpts.attemptInverted) {
         result = scan(binarized.getInverted());
     }
     return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,10 +54,24 @@ function scan(matrix: BitMatrix): QRCode | null {
   };
 }
 
-function jsQR(data: Uint8ClampedArray, width: number, height: number): QRCode | null {
+export interface Options {
+  attemptInverted?: boolean;
+}
+
+const defaultOptions: Options = {
+  attemptInverted: true,
+};
+
+function jsQR(data: Uint8ClampedArray, width: number, height: number, options?: Options): QRCode | null {
+
+  const actualOpts = defaultOptions;
+  Object.keys(options || {}).forEach(opt => {
+    (actualOpts as any)[opt] = (options as any)[opt];
+  });
+
   const binarized = binarize(data, width, height);
   let result = scan(binarized);
-  if (!result) {
+  if (!result && actualOpts.attemptInverted) {
     result = scan(binarized.getInverted());
   }
   return result;


### PR DESCRIPTION
Inverting the image in the case of not finding a code in the initial image introduces a ~50% performance hit. This adds an options object to allow disabling the inversion if you don't expect to be scanning inverted QRs. 

Defaults to the existing behavior (image inversion) but adds a note to the readme that this will probably be disabled in a future backwards incompatible change. 

This also sets up the options object for #76. 