### PR TITLE
add esm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A pure javascript QR code reading library that takes in raw images and will locate, extract and parse any QR code found within.",
   "repository": "https://github.com/cozmo/jsQR",
   "main": "./dist/jsQR.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "contributors": [
     {
@@ -33,7 +34,9 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "./node_modules/.bin/webpack",
+    "build": "npm run build:umd && npm run build:esm",
+    "build:umd": "./node_modules/.bin/webpack",
+    "build:esm": "tsc --target ES2015 --module ES2015 --moduleResolution node",
     "watch": "./node_modules/.bin/webpack --watch",
     "test": "./node_modules/.bin/jest",
     "lint": "tslint --project .",


### PR DESCRIPTION
fixes #107 and #111 

This PR can be a breaking change for people who use Webpack with Babel and target ES5 browsers because it introduces `module` field. 
By default, Webpack will start to use the file specified in the `module`, which is ES2015.
And Babel by default will not transpile it because it ignores node_modules.
So bundled js will contain ES2015 code and may fail in old browsers like IE11.

So I suggest to release it under 2.0.0 and migration path will be to configure Babel properly if needed.