### PR TITLE
Fix "onlyInvert" inversionAttempts option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ function jsQR(data: Uint8ClampedArray, width: number, height: number, providedOp
     (options as any)[opt] = (providedOptions as any)[opt] || (options as any)[opt];
   });
 
-  const shouldInvert = options.inversionAttempts === "attemptBoth" || options.inversionAttempts === "invertFirst";
+  const shouldInvert = options.inversionAttempts === "attemptBoth" || options.inversionAttempts === "invertFirst" || options.inversionAttempts === "onlyInvert";
   const tryInvertedFirst = options.inversionAttempts === "onlyInvert" || options.inversionAttempts === "invertFirst";
   const {binarized, inverted} = binarize(data, width, height, shouldInvert);
   let result = scan(tryInvertedFirst ? inverted : binarized);


### PR DESCRIPTION
Fixes #118.

`shouldInvert` should also be true if `options.inversionAttempts` equals "onlyInvert".