### PR TITLE
Return the extracted BitMatrix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export interface QRCode {
 
     bottomRightAlignmentPattern?: Point;
   };
+  matrix: BitMatrix;
 }
 
 function scan(matrix: BitMatrix): QRCode | null {
@@ -51,6 +52,7 @@ function scan(matrix: BitMatrix): QRCode | null {
 
       bottomRightAlignmentPattern: location.alignmentPattern,
     },
+    matrix: extracted.matrix,
   };
 }
 


### PR DESCRIPTION
Return the extracted BitMatrix `extracted.matrix` as additional property `matrix` of the result.
(This allows the caller to reproduce an exact copy of the read QR code, e.g. together with the decoded data.)
See #123 