### PR TITLE
chore(package): remove unnecessary binstubs path

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "./node_modules/.bin/webpack",
-    "watch": "./node_modules/.bin/webpack --watch",
-    "test": "./node_modules/.bin/jest",
+    "build": "webpack",
+    "watch": "webpack --watch",
+    "test": "jest",
     "lint": "tslint --project .",
-    "generate-test-data": "node_modules/.bin/ts-node --project tests/ tests/generate-test-data.ts"
+    "generate-test-data": "ts-node --project tests/ tests/generate-test-data.ts"
   },
   "jest": {
     "testRegex": ".*test.ts",


### PR DESCRIPTION
NPM (and Yarn) both add the relevant binstubs path to `$PATH`, so you don't need to add it explicitly. On top of that, this hardcodes a `node_modules` layout that may not always be correct. If you were to use Yarn v2 with Zero Install, for example, it never unpacks packages into `node_modules` at all. NPM may do something similar in the future.