### PR TITLE
Adds the QR version to the object returned by jsQR

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ If a QR is able to be decoded the library will return an object with the followi
 
 - `binaryData` - `Uint8ClampedArray` - The raw bytes of the QR code.
 - `data` - The string version of the QR code data.
+- `chunks` - The QR chunks.
+- `version` - The QR version.
 - `location` - An object with keys describing key points of the QR code. Each key is a point of the form `{x: number, y: number}`.
 Has points for the following locations.
   - Corners - `topRightCorner`/`topLeftCorner`/`bottomRightCorner`/`bottomLeftCorner`;

--- a/dist/decoder/decodeData/index.d.ts
+++ b/dist/decoder/decodeData/index.d.ts
@@ -15,6 +15,7 @@ export interface DecodedQR {
     text: string;
     bytes: number[];
     chunks: Chunks;
+    version: number;
 }
 export declare enum Mode {
     Numeric = "numeric",

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4,6 +4,7 @@ export interface QRCode {
     binaryData: number[];
     data: string;
     chunks: Chunks;
+    version: number;
     location: {
         topRightCorner: Point;
         topLeftCorner: Point;

--- a/dist/jsQR.js
+++ b/dist/jsQR.js
@@ -342,6 +342,7 @@ function scan(matrix) {
                 binaryData: decoded.bytes,
                 data: decoded.text,
                 chunks: decoded.chunks,
+                version: decoded.version,
                 location: {
                     topRightCorner: extracted.mappingFunction(location_1.dimension, 0),
                     topLeftCorner: extracted.mappingFunction(0, 0),
@@ -956,6 +957,7 @@ function decode(data, version) {
         text: "",
         bytes: [],
         chunks: [],
+        version: version,
     };
     while (stream.available() >= 4) {
         var mode = stream.readBits(4);

--- a/docs/jsQR.js
+++ b/docs/jsQR.js
@@ -342,6 +342,7 @@ function scan(matrix) {
                 binaryData: decoded.bytes,
                 data: decoded.text,
                 chunks: decoded.chunks,
+                version: decoded.version,
                 location: {
                     topRightCorner: extracted.mappingFunction(location_1.dimension, 0),
                     topLeftCorner: extracted.mappingFunction(0, 0),
@@ -956,6 +957,7 @@ function decode(data, version) {
         text: "",
         bytes: [],
         chunks: [],
+        version: version,
     };
     while (stream.available() >= 4) {
         var mode = stream.readBits(4);

--- a/src/decoder/decodeData/index.ts
+++ b/src/decoder/decodeData/index.ts
@@ -23,6 +23,7 @@ export interface DecodedQR {
   text: string;
   bytes: number[];
   chunks: Chunks;
+  version: number;
 }
 
 export enum Mode {
@@ -178,6 +179,7 @@ export function decode(data: Uint8ClampedArray, version: number): DecodedQR {
     text: "",
     bytes: [],
     chunks: [],
+    version: version,
   };
 
   while (stream.available() >= 4) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {binarize} from "./binarizer";
 import {BitMatrix} from "./BitMatrix";
 import {Chunks} from "./decoder/decodeData";
 import {decode} from "./decoder/decoder";
+import { Version } from "./decoder/version";
 import {extract} from "./extractor";
 import {locate, Point} from "./locator";
 
@@ -9,6 +10,7 @@ export interface QRCode {
   binaryData: number[];
   data: string;
   chunks: Chunks;
+  version: number;
   location: {
     topRightCorner: Point;
     topLeftCorner: Point;
@@ -37,6 +39,7 @@ function scan(matrix: BitMatrix): QRCode | null {
         binaryData: decoded.bytes,
         data: decoded.text,
         chunks: decoded.chunks,
+        version: decoded.version,
         location: {
           topRightCorner: extracted.mappingFunction(location.dimension, 0),
           topLeftCorner: extracted.mappingFunction(0, 0),


### PR DESCRIPTION
Added the QR version to the object returned by the jsQR function.

I'm implementing a spec that limits the size of QR code, so learning the scanned QR version would be useful to know and report to the application. 