### PR TITLE
Fix exports type definitions

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,23 +1,25 @@
 import { Chunks } from "./decoder/decodeData";
 import { Point } from "./locator";
-export interface QRCode {
-    binaryData: number[];
-    data: string;
-    chunks: Chunks;
-    version: number;
-    location: {
-        topRightCorner: Point;
-        topLeftCorner: Point;
-        bottomRightCorner: Point;
-        bottomLeftCorner: Point;
-        topRightFinderPattern: Point;
-        topLeftFinderPattern: Point;
-        bottomLeftFinderPattern: Point;
-        bottomRightAlignmentPattern?: Point;
-    };
+declare namespace jsQR {
+    interface QRCode {
+        binaryData: number[];
+        data: string;
+        chunks: Chunks;
+        version: number;
+        location: {
+            topRightCorner: Point;
+            topLeftCorner: Point;
+            bottomRightCorner: Point;
+            bottomLeftCorner: Point;
+            topRightFinderPattern: Point;
+            topLeftFinderPattern: Point;
+            bottomLeftFinderPattern: Point;
+            bottomRightAlignmentPattern?: Point;
+        };
+    }
+    interface Options {
+        inversionAttempts?: "dontInvert" | "onlyInvert" | "attemptBoth" | "invertFirst";
+    }
 }
-export interface Options {
-    inversionAttempts?: "dontInvert" | "onlyInvert" | "attemptBoth" | "invertFirst";
-}
-declare function jsQR(data: Uint8ClampedArray, width: number, height: number, providedOptions?: Options): QRCode | null;
-export default jsQR;
+declare function jsQR(data: Uint8ClampedArray, width: number, height: number, providedOptions?: jsQR.Options): jsQR.QRCode | null;
+export = jsQR;

--- a/dist/jsQR.js
+++ b/dist/jsQR.js
@@ -323,7 +323,6 @@ exports.default = GenericGFPoly;
 
 "use strict";
 
-Object.defineProperty(exports, "__esModule", { value: true });
 var binarizer_1 = __webpack_require__(4);
 var decoder_1 = __webpack_require__(5);
 var extractor_1 = __webpack_require__(11);
@@ -377,7 +376,7 @@ function jsQR(data, width, height, providedOptions) {
     return result;
 }
 jsQR.default = jsQR;
-exports.default = jsQR;
+module.exports = jsQR;
 
 
 /***/ }),

--- a/docs/jsQR.js
+++ b/docs/jsQR.js
@@ -323,7 +323,6 @@ exports.default = GenericGFPoly;
 
 "use strict";
 
-Object.defineProperty(exports, "__esModule", { value: true });
 var binarizer_1 = __webpack_require__(4);
 var decoder_1 = __webpack_require__(5);
 var extractor_1 = __webpack_require__(11);
@@ -377,7 +376,7 @@ function jsQR(data, width, height, providedOptions) {
     return result;
 }
 jsQR.default = jsQR;
-exports.default = jsQR;
+module.exports = jsQR;
 
 
 /***/ }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,26 +6,32 @@ import { Version } from "./decoder/version";
 import {extract} from "./extractor";
 import {locate, Point} from "./locator";
 
-export interface QRCode {
-  binaryData: number[];
-  data: string;
-  chunks: Chunks;
-  version: number;
-  location: {
-    topRightCorner: Point;
-    topLeftCorner: Point;
-    bottomRightCorner: Point;
-    bottomLeftCorner: Point;
+declare namespace jsQR {
+  interface QRCode {
+    binaryData: number[];
+    data: string;
+    chunks: Chunks;
+    version: number;
+    location: {
+      topRightCorner: Point;
+      topLeftCorner: Point;
+      bottomRightCorner: Point;
+      bottomLeftCorner: Point;
 
-    topRightFinderPattern: Point;
-    topLeftFinderPattern: Point;
-    bottomLeftFinderPattern: Point;
+      topRightFinderPattern: Point;
+      topLeftFinderPattern: Point;
+      bottomLeftFinderPattern: Point;
 
-    bottomRightAlignmentPattern?: Point;
-  };
+      bottomRightAlignmentPattern?: Point;
+    };
+  }
+
+  interface Options {
+    inversionAttempts?: "dontInvert" | "onlyInvert" | "attemptBoth" | "invertFirst";
+  }
 }
 
-function scan(matrix: BitMatrix): QRCode | null {
+function scan(matrix: BitMatrix): jsQR.QRCode | null {
   const locations = locate(matrix);
   if (!locations) {
     return null;
@@ -58,15 +64,11 @@ function scan(matrix: BitMatrix): QRCode | null {
   return null;
 }
 
-export interface Options {
-  inversionAttempts?: "dontInvert" | "onlyInvert" | "attemptBoth" | "invertFirst";
-}
-
-const defaultOptions: Options = {
+const defaultOptions: jsQR.Options = {
   inversionAttempts: "attemptBoth",
 };
 
-function jsQR(data: Uint8ClampedArray, width: number, height: number, providedOptions: Options = {}): QRCode | null {
+function jsQR(data: Uint8ClampedArray, width: number, height: number, providedOptions: jsQR.Options = {}): jsQR.QRCode | null {
 
   const options = defaultOptions;
   Object.keys(options || {}).forEach(opt => { // Sad implementation of Object.assign since we target es5 not es6
@@ -84,4 +86,4 @@ function jsQR(data: Uint8ClampedArray, width: number, height: number, providedOp
 }
 
 (jsQR as any).default = jsQR;
-export default jsQR;
+export = jsQR;

--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,7 @@
         "arrow-parens": false,
         "max-line-length": [true, 140],
         "interface-name": false,
+        "no-namespace": false,
         "object-literal-sort-keys": false
     },
     "rulesDirectory": []


### PR DESCRIPTION
According to the type definitions, this library had to be used like this:

```js
// CJS
const jsQR = require('jsqr')

jsQR.default(/* … */)
```

```js
// ESM
import jsQR from 'jsqr'

jsQR.default(/* … */)
```

However, this doesn’t match the instructions from the readme.

This issue has become more apparent since the introduction of the `"module": "node16"` option in TypeScript 4.7. The correct way to type `module.exports =` is `export =`.

People can still use default imports when compiling to CJS. This requires them to use the `esModuleInterop` option (which they need anyway if they want to use it with other libraries).